### PR TITLE
keys experiment in 5.18 no longer valid in later perl versions

### DIFF
--- a/tdr-repository
+++ b/tdr-repository
@@ -42,7 +42,7 @@ if ($debug) { print Dumper(\%confighash);}
 if (! (%confighash && $confighash{'repository'})) {
     die "No <repository> block in configuration file!\n";
 }
-my @repos = keys $confighash{'repository'};
+my @repos = keys %{$confighash{'repository'}};
 
 # If the name was missing, then all the other config options become keys.
 # Only one block allowed, so using only one key as way to differentiate.


### PR DESCRIPTION
An experiment by the Perl authors in the use of 'keys' was removed in perl version 5.23.  Since Ubuntu 18 (bionic) runs Perl 5.26 (and likely newer releases of perl will come in through the usual OS maintenance) the use of the keyword at line 42 is illegal, so this changes makes this function once again.